### PR TITLE
chore (PHP): Address PHP 8.4 deprecations

### DIFF
--- a/src/FileLoader.php
+++ b/src/FileLoader.php
@@ -24,7 +24,7 @@ abstract class FileLoader extends BaseFileLoader
     /**
      * {@inheritdoc}
      */
-    public function load(mixed $resource, string $type = null): mixed
+    public function load(mixed $resource, ?string $type = null): mixed
     {
         if (!stream_is_local($resource)) {
             throw new \Exception(sprintf('This is not a local file "%s".', $resource));

--- a/src/JsonLoader.php
+++ b/src/JsonLoader.php
@@ -64,7 +64,7 @@ class JsonLoader extends FileLoader
     /**
      * {@inheritdoc}
      */
-    public function supports(mixed $resource, string $type = null): bool
+    public function supports(mixed $resource, ?string $type = null): bool
     {
         return is_string($resource) && 'json' === pathinfo(
             $resource,

--- a/src/PhpLoader.php
+++ b/src/PhpLoader.php
@@ -31,7 +31,7 @@ class PhpLoader extends FileLoader
     /**
      * {@inheritdoc}
      */
-    public function supports(mixed $resource, string $type = null): bool
+    public function supports(mixed $resource, ?string $type = null): bool
     {
         return is_string($resource) && 'php' === pathinfo(
             $resource,

--- a/src/YamlLoader.php
+++ b/src/YamlLoader.php
@@ -48,7 +48,7 @@ class YamlLoader extends FileLoader
     /**
      * {@inheritdoc}
      */
-    public function supports(mixed $resource, string $type = null): bool
+    public function supports(mixed $resource, ?string $type = null): bool
     {
         return is_string($resource) && 'yml' === pathinfo(
             $resource,


### PR DESCRIPTION
PHP 8.4 deprecated implicitly nullable parameters. Fix these deprecations by making implicitly nullable parameters explicitly nullable.